### PR TITLE
change grid order for skill list on tablet and desktop

### DIFF
--- a/src/components/ResumeContent.vue
+++ b/src/components/ResumeContent.vue
@@ -78,6 +78,11 @@
           "skillCat"
           "skillList";
         margin-bottom: 32px;
+        @media (min-width: 576px) {
+          grid-template-areas:
+            "skillCat skillList";
+          grid-template-columns: 1fr 2fr;
+        }
       }
       &--skillCat {
         grid-area: skillCat;


### PR DESCRIPTION
Removes table and uses CSS grid to organize the skills section of the resume.